### PR TITLE
Fix favicon link

### DIFF
--- a/assets/vite.svg
+++ b/assets/vite.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="purple" />
+  <text x="50" y="55" font-size="45" text-anchor="middle" fill="white">V</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/assets/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Éditeur de Clips Vidéo</title>
     <script type="module" crossorigin src="/assets/index-BzpbYwPT.js"></script>


### PR DESCRIPTION
## Summary
- correct favicon link to use assets/vite.svg
- add newline at EOF
- add a simple vite.svg placeholder icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842155309e48325a24df7170843b192